### PR TITLE
fix(ci): shard the daily sync one job per court so it stops hitting the 6h ceiling

### DIFF
--- a/.github/workflows/court-data-pipeline.yml
+++ b/.github/workflows/court-data-pipeline.yml
@@ -26,8 +26,44 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  run-data-pipeline:
+  # Emits the matrix of court codes. One court per job, so no single slow court
+  # can consume the whole run's wall-clock budget and starve the rest.
+  select-courts:
     runs-on: ubuntu-latest
+    outputs:
+      courts: ${{ steps.select.outputs.courts }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Select courts
+        id: select
+        env:
+          INPUT_COURT_CODE: ${{ github.event.inputs.court_code }}
+        run: |
+          if [ -n "$INPUT_COURT_CODE" ]; then
+            COURTS=$(jq -cn --arg c "$INPUT_COURT_CODE" '[$c]')
+          else
+            COURTS=$(jq -c 'keys' court-codes.json)
+          fi
+          echo "Courts to process: $COURTS"
+          echo "courts=$COURTS" >> "$GITHUB_OUTPUT"
+
+  run-data-pipeline:
+    needs: select-courts
+    runs-on: ubuntu-latest
+    # Below GitHub's 6h hard ceiling on job execution. A job killed by the
+    # platform ceiling is reported as "cancelled", which does not turn the badge
+    # red — an explicit timeout is reported as "failure", which does.
+    timeout-minutes: 330
+    strategy:
+      fail-fast: false
+      # Total concurrent requests against the eCourts portal is unchanged:
+      # previously one job with --max_workers 4, now four jobs with
+      # --max_workers 1. Sharding buys wall-clock, not portal pressure.
+      max-parallel: 4
+      matrix:
+        court: ${{ fromJSON(needs.select-courts.outputs.courts) }}
     permissions:
       contents: write
       id-token: write
@@ -61,14 +97,11 @@ jobs:
 
       - name: Run court data pipeline
         env:
-          INPUT_COURT_CODE: ${{ github.event.inputs.court_code }}
+          MATRIX_COURT_CODE: ${{ matrix.court }}
           INPUT_START_DATE: ${{ github.event.inputs.start_date }}
           INPUT_END_DATE: ${{ github.event.inputs.end_date }}
         run: |
-          ARGS="--sync-s3 --max_workers 4 --day_step 5"
-          if [ -n "$INPUT_COURT_CODE" ]; then
-            ARGS="$ARGS --court_code $INPUT_COURT_CODE"
-          fi
+          ARGS="--sync-s3 --max_workers 1 --day_step 5 --court_code $MATRIX_COURT_CODE"
           if [ -n "$INPUT_START_DATE" ]; then
             ARGS="$ARGS --start_date $INPUT_START_DATE"
           fi


### PR DESCRIPTION
Fixes #30.

## The problem

The daily pipeline processes all 25 courts inside a single job. Since run #105 (2026-08-04), every run has ended `cancelled` after almost exactly six hours — GitHub's hard ceiling on job execution time. Run #123 is typical: started `02:43:57Z`, ended `08:44:12Z`, **6h 00m 15s**.

The job gets through the first court and is killed before reaching the rest, which is why `court=9_13` (Allahabad) stayed current in the bucket while the other 24 `year=2026` partitions have not moved since 4 August.

It went unnoticed for 18 days because the platform reports that ceiling as `cancelled`, not `failed` — so the badge never turned red.

## The change

**Shard one job per court.** A small `select-courts` job reads `court-codes.json` and emits the matrix; `run-data-pipeline` then runs per court with `fail-fast: false`. Each court gets its own six-hour budget rather than sharing one across all 25, and one slow court can no longer starve the other 24.

**Add `timeout-minutes: 330`**, just below the platform ceiling. A job stopped by an explicit timeout is reported as `failure` — which turns the badge red — whereas one stopped by the ceiling is reported as `cancelled`. This is the part that makes the next stall visible on the day it happens rather than three weeks later.

## Portal load is unchanged, deliberately

The README asks contributors to avoid high-concurrency scraping, so this buys wall-clock rather than throughput:

| | before | after |
|---|---|---|
| jobs in flight | 1 | 4 (`max-parallel: 4`) |
| `--max_workers` per job | 4 | 1 |
| **concurrent requests to eCourts** | **4** | **4** |

## Notes

- The `court_code` workflow_dispatch input still works — it produces a single-entry matrix, so a one-court manual run behaves as before.
- Court codes come from `court-codes.json` in tilde form (`9~13`), which `--court_code` accepts.
- The pipeline performs no git writes and keeps its resume state per court in the S3 index files, so per-court jobs do not race.
- The first run after this lands has 18 days of backlog to work through; `--day_step 5` with S3 auto-detect should absorb it over a run or two.
- Untested against your AWS OIDC role, since I can't run the workflow here. Worth a `workflow_dispatch` with a single `court_code` first. One thing to check on your side: `role-duration-seconds: 21600` is left as-is, so the role's `MaxSessionDuration` still needs to allow it — unchanged from today, but now requested by several jobs at once.

Thanks for maintaining this dataset — we rely on it, and would rather send a fix upstream than work around it.
