### PR TITLE
Fix resume-cursor pin that stalls the daily sync, and fail loudly when courts are starved

### DIFF
--- a/.github/workflows/court-data-pipeline.yml
+++ b/.github/workflows/court-data-pipeline.yml
@@ -28,6 +28,11 @@ concurrency:
 jobs:
   run-data-pipeline:
     runs-on: ubuntu-latest
+    # Without this the job inherits GitHub's hard 6h cap, and a cap kill is
+    # reported as "cancelled" — which reads like someone stopped the run rather
+    # than a broken sync. Stay under the cap so the pipeline's own budget
+    # (--max-runtime-minutes) stops it first and it exits non-zero instead.
+    timeout-minutes: 350
     permissions:
       contents: write
       id-token: write
@@ -65,7 +70,7 @@ jobs:
           INPUT_START_DATE: ${{ github.event.inputs.start_date }}
           INPUT_END_DATE: ${{ github.event.inputs.end_date }}
         run: |
-          ARGS="--sync-s3 --max_workers 4 --day_step 5"
+          ARGS="--sync-s3 --max_workers 4 --day_step 5 --max-runtime-minutes 300"
           if [ -n "$INPUT_COURT_CODE" ]; then
             ARGS="$ARGS --court_code $INPUT_COURT_CODE"
           fi

--- a/download.py
+++ b/download.py
@@ -58,6 +58,12 @@ TASK_DOWNLOAD_ATTEMPTS = 3
 # when failures are widespread (ratio) or large in absolute terms (count).
 FAILURE_RATIO_THRESHOLD = 0.2
 FAILURE_COUNT_THRESHOLD = 10
+# Wall-clock budget for a whole run. Must stay below the CI job timeout so the
+# run stops itself - draining in-flight uploads and advancing resume cursors -
+# instead of being killed mid-write. A run that cannot reach every court is
+# reported as a failure: an unattempted court is a silent data gap, not a
+# transient error.
+DEFAULT_MAX_RUNTIME_MINUTES = 300
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 warnings.filterwarnings("ignore")
@@ -340,6 +346,7 @@ def run(
     compress_pdfs=False,
     dist_code: Optional[str] = None,
     use_default_dist_codes: bool = True,
+    max_runtime_minutes: Optional[int] = DEFAULT_MAX_RUNTIME_MINUTES,
 ):
     """
     Run the downloader with explicit date ranges.
@@ -349,6 +356,8 @@ def run(
     - Downloads for specified range, skipping already-downloaded files
     - Always checks S3 for existing files to avoid re-downloading
     - Appends to existing tar files in S3 after download
+    - Stops starting new work after max_runtime_minutes and fails the run if
+      any court was left unattempted (pass None to disable the budget)
     """
 
     if isinstance(court_codes, str):
@@ -457,9 +466,22 @@ def run(
     pending_upload: Optional[concurrent.futures.Future] = None
     task_failures = []
     total_tasks = 0
+    unrun_tasks: List[CourtDateTask] = []
+    unattempted_courts: List[str] = []
+    deadline = _run_deadline(max_runtime_minutes)
+    if deadline is not None:
+        print(f"Run budget: {max_runtime_minutes} minute(s)")
 
     # Process each court individually for proper S3 handling
     for court_code in target_courts:
+        if deadline is not None and time.monotonic() >= deadline:
+            unattempted_courts.append(court_code)
+            print(
+                f"\nWARNING: run budget exhausted; court {court_code} was not "
+                f"attempted."
+            )
+            continue
+
         # Resolve per-court start_date. Explicit --start_date on the CLI
         # short-circuits the per-court logic; otherwise look up by the court's
         # S3-format code and fall back to DEFAULT_BOOTSTRAP for brand-new courts.
@@ -502,24 +524,50 @@ def run(
         # Scrape this court in the foreground, then hand the upload off to
         # the background worker so we can start the next court immediately.
         total_tasks += len(tasks)
-        task_failures.extend(_run_tasks(tasks, max_workers, compress_pdfs))
+        court_failures, court_unrun = _run_tasks(
+            tasks, max_workers, compress_pdfs, deadline
+        )
+        task_failures.extend(court_failures)
+        unrun_tasks.extend(court_unrun)
 
         if S3_ENABLED:
             end_date_obj = (
                 datetime.strptime(end_date, "%Y-%m-%d").date() if end_date else None
+            )
+            # Only advance this court's resume cursor as far as it is
+            # contiguously covered, so a failed or unrun range is retried next
+            # run instead of being stepped over.
+            scraped_through = _contiguous_scraped_through(
+                end_date,
+                [task for task, _ in court_failures] + court_unrun,
             )
             if pending_upload is not None:
                 # Wait for previous court's upload to finish before queueing
                 # the next one — bounds disk to ~2 courts at a time.
                 pending_upload.result()
             pending_upload = upload_executor.submit(
-                _upload_court_to_s3, court_code, end_date_obj
+                _upload_court_to_s3, court_code, end_date_obj, scraped_through
             )
 
     if pending_upload is not None:
         pending_upload.result()
     if upload_executor is not None:
         upload_executor.shutdown(wait=True)
+
+    # A court that was never attempted (or a range that never ran) is a silent
+    # data gap, not a transient error, so it is always fatal — unlike the
+    # tolerated task failures below. Raised after the uploads above so whatever
+    # progress the run did make is still persisted.
+    if unattempted_courts or unrun_tasks:
+        raise RuntimeError(
+            f"Run budget of {max_runtime_minutes} minute(s) exhausted before the "
+            f"work was finished: {len(unattempted_courts)} court(s) not attempted "
+            f"({', '.join(unattempted_courts) or 'none'}) and "
+            f"{len(unrun_tasks)} date range(s) not run. Those courts are not "
+            f"being refreshed — raise --max-runtime-minutes, narrow the date "
+            f"window, or backfill the lagging courts with an explicit "
+            f"--court_code run."
+        )
 
     if task_failures:
         failed_tasks = "\n".join(
@@ -550,20 +598,52 @@ def run(
     logger.info("All download tasks completed")
 
 
-def _run_tasks(tasks, max_workers, compression_enabled=False):
-    """Run download tasks without S3 upload"""
+def _run_deadline(max_runtime_minutes):
+    """Monotonic timestamp after which no new work is started."""
+    if not max_runtime_minutes:
+        return None
+    return time.monotonic() + max_runtime_minutes * 60
+
+
+def _contiguous_scraped_through(end_date, incomplete_tasks):
+    """Date a court is contiguously covered through.
+
+    The resume cursor must never step over a range that failed or never ran,
+    so it stops the day before the earliest such range. With no incomplete
+    ranges the court is covered through end_date.
+    """
+    if not incomplete_tasks:
+        return end_date
+    earliest = min(task.from_date for task in incomplete_tasks)
+    cutoff = datetime.strptime(earliest, "%Y-%m-%d") - timedelta(days=1)
+    return min(cutoff.strftime("%Y-%m-%d"), end_date)
+
+
+def _run_tasks(tasks, max_workers, compression_enabled=False, deadline=None):
+    """Run download tasks without S3 upload.
+
+    Returns (failures, unrun_tasks). Once `deadline` (a time.monotonic()
+    value) passes, tasks that have not started yet are cancelled so the run can
+    finish cleanly — draining uploads and advancing cursors — rather than being
+    killed mid-write when the CI job hits its timeout.
+    """
     failures = []
+    unrun = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         with tqdm(total=len(tasks), desc="Processing tasks", unit="task") as pbar:
             future_to_task = {
                 executor.submit(process_task, task, compression_enabled): task
                 for task in tasks
             }
+            budget_exhausted = False
             for future in concurrent.futures.as_completed(future_to_task):
                 task = future_to_task[future]
                 pbar.set_description(
                     f"Processing {task.court_code} ({task.from_date} to {task.to_date})"
                 )
+                if future.cancelled():
+                    pbar.update(1)
+                    continue
                 try:
                     future.result()
                 except Exception as e:
@@ -575,7 +655,22 @@ def _run_tasks(tasks, max_workers, compression_enabled=False):
                         e,
                     )
                 pbar.update(1)
-    return failures
+                if (
+                    not budget_exhausted
+                    and deadline is not None
+                    and time.monotonic() >= deadline
+                ):
+                    budget_exhausted = True
+                    for pending_future, pending_task in future_to_task.items():
+                        if pending_future.cancel():
+                            unrun.append(pending_task)
+                    logger.error(
+                        "Run budget exhausted; cancelled %d not-yet-started "
+                        "range(s) for court %s",
+                        len(unrun),
+                        task.court_code,
+                    )
+    return failures, unrun
 
 
 def group_files_by_year(files: List[Path]) -> Dict[int, List[Path]]:
@@ -635,7 +730,7 @@ def filter_metadata_files_by_existing_identity(
     return new_files
 
 
-def _upload_court_to_s3(court_code, end_date):
+def _upload_court_to_s3(court_code, end_date, scraped_through=None):
     """
     Scan local files for a court, diff against S3, and upload.
 
@@ -643,6 +738,11 @@ def _upload_court_to_s3(court_code, end_date):
     scraping the next court while this one uploads. If the process dies
     mid-upload, local files are preserved (we only unlink after successful
     upload), so the next run can resume by re-diffing.
+
+    scraped_through is the date this court is contiguously covered through
+    (YYYY-MM-DD). Defaults to end_date. Callers that only got part way through
+    a court's ranges should pass the earlier date so the resume cursor never
+    steps over a range that was not actually scraped.
     """
     print(f"\nCollecting NEW files for {court_code}...")
     downloaded_files = {"metadata": [], "data": []}
@@ -703,6 +803,11 @@ def _upload_court_to_s3(court_code, end_date):
     total_on_disk = 0
     total_new = 0
     upload_failures = []
+    # Year partitions each bench touched, and benches whose upload failed.
+    # Collected here so resume cursors can be advanced below for EVERY bench of
+    # this court, including benches that produced no new files this run.
+    bench_year_partitions: Dict[str, set] = {}
+    benches_blocked: set = set()
 
     try:
         for bench in target_benches:
@@ -768,6 +873,7 @@ def _upload_court_to_s3(court_code, end_date):
 
             synced_years = []
             failed_years = set()
+            bench_year_partitions[bench] = set(bench_files.keys())
 
             for year, year_files in bench_files.items():
                 try:
@@ -814,26 +920,8 @@ def _upload_court_to_s3(court_code, end_date):
                     upload_failures.append(message)
                     logger.error(message)
 
-            # Advance the resume cursor for every year partition we know about
-            # for this bench. We use the run's end_date (what we scraped
-            # THROUGH) rather than max decision date, because the scrape
-            # operates on decision-date ranges and end_date is the actual
-            # boundary. Write to the data index so auto-detect sees it.
-            if end_date is not None and not failed_years:
-                scraped_through_str = end_date.strftime("%Y-%m-%d") if hasattr(end_date, "strftime") else str(end_date)
-                # Write to all year partitions this bench has touched, plus
-                # the end_date's year (in case the bench has no files for it yet)
-                years_to_update = set(bench_files.keys()) | {end_date.year if hasattr(end_date, "year") else int(scraped_through_str[:4])}
-                for yr in years_to_update:
-                    try:
-                        write_scraped_through_date(
-                            "data", yr, court_code_underscore, bench, scraped_through_str
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            f"Failed to write scraped_through_date for "
-                            f"{yr}/{court_code_underscore}/{bench}: {e}"
-                        )
+            if failed_years:
+                benches_blocked.add(bench)
 
             # Clean up only files that were successfully uploaded.
             # Files with unparseable dates were never uploaded and should be preserved.
@@ -857,6 +945,14 @@ def _upload_court_to_s3(court_code, end_date):
                     f"(unparseable dates or upload failures)"
                 )
 
+        _advance_court_resume_cursors(
+            court_code_underscore,
+            target_benches,
+            scraped_through if scraped_through is not None else end_date,
+            bench_year_partitions,
+            benches_blocked,
+        )
+
         if upload_failures:
             raise RuntimeError(
                 "S3 sync completed with failures:\n- " + "\n- ".join(upload_failures)
@@ -866,6 +962,52 @@ def _upload_court_to_s3(court_code, end_date):
         print(f"Error during S3 upload: {e}")
         traceback.print_exc()
         raise
+
+
+def _advance_court_resume_cursors(
+    court_code_underscore,
+    target_benches,
+    scraped_through,
+    bench_year_partitions,
+    benches_blocked,
+):
+    """Advance scraped_through_date for every bench of this court.
+
+    We use the date scraped THROUGH rather than max decision date, because the
+    scrape operates on decision-date ranges and that is the actual boundary.
+    Write to the data index so auto-detect sees it.
+
+    Benches that produced no new files are included on purpose. The search is
+    issued per court, so a bench with no rows in the range has genuinely been
+    covered - "no judgments" is not "not looked at". Skipping those benches
+    left them with no cursor at all, and run() resolves a court's start date as
+    the MIN across its benches, so a single quiet bench pinned its whole court
+    to an ever-growing re-scrape window (see issue #30).
+    """
+    if scraped_through is None:
+        return
+    scraped_through_str = (
+        scraped_through.strftime("%Y-%m-%d")
+        if hasattr(scraped_through, "strftime")
+        else str(scraped_through)
+    )
+    default_year = int(scraped_through_str[:4])
+    for bench in target_benches:
+        if bench in benches_blocked:
+            continue
+        # All year partitions this bench has touched, plus the cursor's own
+        # year (in case the bench has no files for it yet).
+        years_to_update = set(bench_year_partitions.get(bench, ())) | {default_year}
+        for yr in sorted(years_to_update):
+            try:
+                write_scraped_through_date(
+                    "data", yr, court_code_underscore, bench, scraped_through_str
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to write scraped_through_date for "
+                    f"{yr}/{court_code_underscore}/{bench}: {e}"
+                )
 
 
 class Downloader:
@@ -1540,6 +1682,16 @@ Examples:
         "--max_workers", type=int, default=2, help="Number of parallel workers"
     )
     parser.add_argument(
+        "--max-runtime-minutes",
+        type=int,
+        default=DEFAULT_MAX_RUNTIME_MINUTES,
+        help=(
+            "Wall-clock budget for the run. Stops starting new work once "
+            "exceeded and exits non-zero if any court was left unattempted. "
+            "Keep it below the CI job timeout. Pass 0 to disable."
+        ),
+    )
+    parser.add_argument(
         "--fetch_dates",
         action="store_true",
         help="Just display latest dates from S3 index files without downloading",
@@ -1606,6 +1758,7 @@ Examples:
             compress_pdfs=args.compress_pdfs,
             dist_code=args.dist_code,
             use_default_dist_codes=args.default_dist_codes,
+            max_runtime_minutes=args.max_runtime_minutes or None,
         )
 
 """

--- a/tests/test_download_s3_sync.py
+++ b/tests/test_download_s3_sync.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import time
 import unittest
 from contextlib import ExitStack
 from datetime import date
@@ -218,12 +219,13 @@ class ScrapeFailureTests(unittest.TestCase):
             "process_task",
             side_effect=[RuntimeError("bad day"), None],
         ) as process_mock:
-            failures = download._run_tasks(tasks, max_workers=1)
+            failures, unrun = download._run_tasks(tasks, max_workers=1)
 
         self.assertEqual(process_mock.call_count, 2)
         self.assertEqual(len(failures), 1)
         self.assertIs(failures[0][0], tasks[0])
         self.assertRegex(str(failures[0][1]), "bad day")
+        self.assertEqual(unrun, [])
 
     def test_download_propagates_terminal_search_errors(self):
         task = download.CourtDateTask("9~13", "2025-01-01", "2025-01-07")
@@ -312,6 +314,144 @@ class ScrapeFailureTests(unittest.TestCase):
 
         self.assertTrue(result)
         self.assertEqual(pdf_path.read_bytes(), PdfResponse.content)
+
+
+class ResumeCursorTests(unittest.TestCase):
+    """Cursors must advance for every bench of a court, not just busy ones.
+
+    run() resolves a court's start date as the MIN across its benches, so a
+    bench that is never given a cursor pins its whole court to an ever-growing
+    re-scrape window (issue #30).
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.prev_cwd = os.getcwd()
+        os.chdir(self.tmpdir.name)
+        self.addCleanup(os.chdir, self.prev_cwd)
+
+        # Only "busybench" has files on disk; "quietbench" produced nothing.
+        bench_dir = Path("data/court/cnrorders/busybench/orders/2025")
+        bench_dir.mkdir(parents=True, exist_ok=True)
+        (bench_dir / "case.json").write_text('{"raw_html":"<div></div>"}')
+        (bench_dir / "case.pdf").write_bytes(b"%PDF-1.4")
+
+    def _patches(self):
+        return [
+            patch.object(
+                download,
+                "load_court_bench_mapping",
+                return_value={"busybench": "27_1", "quietbench": "27_1"},
+            ),
+            patch.object(download, "get_bench_codes", return_value={}),
+            patch.object(download, "extract_decision_date_from_json", return_value=2025),
+            patch.object(download, "get_existing_files_from_s3_v2", return_value=[]),
+            patch.object(
+                download, "get_existing_judgment_identities_from_parquet", return_value=set()
+            ),
+            patch.object(download.cache_store, "invalidate"),
+            patch.object(download, "create_and_upload_parquet_files", return_value=True),
+            patch.object(download, "upload_files_to_s3_v2"),
+            patch.object(download, "write_scraped_through_date"),
+        ]
+
+    def test_bench_with_no_new_files_still_advances_its_cursor(self):
+        with ExitStack() as stack:
+            mocks = [stack.enter_context(p) for p in self._patches()]
+            cursor_mock = mocks[8]
+
+            download._upload_court_to_s3("27~1", date(2026, 8, 24))
+
+        benches_written = {c.args[3] for c in cursor_mock.call_args_list}
+        self.assertEqual(benches_written, {"busybench", "quietbench"})
+        self.assertIn(
+            call("data", 2026, "27_1", "quietbench", "2026-08-24"),
+            cursor_mock.call_args_list,
+        )
+
+    def test_explicit_scraped_through_overrides_end_date(self):
+        with ExitStack() as stack:
+            mocks = [stack.enter_context(p) for p in self._patches()]
+            cursor_mock = mocks[8]
+
+            download._upload_court_to_s3("27~1", date(2026, 8, 24), "2026-08-10")
+
+        written_dates = {c.args[4] for c in cursor_mock.call_args_list}
+        self.assertEqual(written_dates, {"2026-08-10"})
+
+
+class ContiguousCursorTests(unittest.TestCase):
+    def test_full_coverage_uses_end_date(self):
+        self.assertEqual(
+            download._contiguous_scraped_through("2026-08-24", []), "2026-08-24"
+        )
+
+    def test_stops_the_day_before_the_earliest_incomplete_range(self):
+        incomplete = [
+            download.CourtDateTask("27~1", "2026-08-16", "2026-08-20"),
+            download.CourtDateTask("27~1", "2026-08-06", "2026-08-10"),
+        ]
+        self.assertEqual(
+            download._contiguous_scraped_through("2026-08-24", incomplete),
+            "2026-08-05",
+        )
+
+
+class RunBudgetTests(unittest.TestCase):
+    """The run must stop itself and say so, rather than be killed by CI."""
+
+    def test_run_tasks_cancels_pending_ranges_past_the_deadline(self):
+        tasks = [
+            download.CourtDateTask("27~1", f"2026-08-{day:02d}", f"2026-08-{day:02d}")
+            for day in range(1, 6)
+        ]
+
+        # Deadline already elapsed: ranges still queued behind the single
+        # worker are cancelled and reported, not silently dropped.
+        def slow_task(_task, _compression=False):
+            time.sleep(0.1)
+
+        with patch.object(download, "process_task", side_effect=slow_task) as process_mock:
+            failures, unrun = download._run_tasks(
+                tasks, max_workers=1, deadline=time.monotonic() - 1
+            )
+
+        self.assertEqual(failures, [])
+        self.assertTrue(unrun, "expected queued ranges to be cancelled")
+        self.assertEqual(process_mock.call_count, len(tasks) - len(unrun))
+        # Cancelled ranges are the tail of the queue, never a gap in the middle.
+        self.assertEqual(
+            [t.from_date for t in unrun],
+            [t.from_date for t in tasks[len(tasks) - len(unrun):]],
+        )
+
+    def test_unattempted_court_fails_the_run(self):
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(
+                    download,
+                    "get_court_codes",
+                    return_value={"9~13": "Allahabad", "27~1": "Bombay"},
+                )
+            )
+            stack.enter_context(
+                patch.object(download, "_run_deadline", return_value=time.monotonic() - 1)
+            )
+            run_mock = stack.enter_context(
+                patch.object(download, "_run_tasks", return_value=([], []))
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "not attempted"):
+                download.run(
+                    start_date="2026-08-20",
+                    end_date="2026-08-24",
+                    day_step=5,
+                    max_runtime_minutes=60,
+                )
+
+        # Budget was already gone, so no court was even started.
+        run_mock.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #30.

### What is happening

Every scheduled run since **5 August** has been killed by GitHub's hard 6-hour job
cap. Because a cap kill is reported as `cancelled` rather than `failure`, it reads
like somebody stopped the run, and it has gone unnoticed for three weeks.

```
2026-08-04  success    3h07m   all 25 courts processed
2026-08-05  cancelled  6h00m   2 courts reached
...
2026-08-14  cancelled  6h00m   2 courts reached
...
2026-08-23  cancelled  6h00m   2 courts reached
```

Annotation on each: `The job has exceeded the maximum execution time of 6h0m0s`.

Courts are processed sequentially in `court-codes.json` order, so the run dies
inside court #2 and **courts #3–#25 have not been scraped since 4 August**. That
matches the bucket exactly: of the 55 objects under
`metadata/parquet/year=2026/`, only `court=9_13/bench=cishclko` is current; 39 are
frozen at 2026-08-04.

### Root cause

`_upload_court_to_s3` skips a bench before the cursor is written when that bench
produced no new files:

```python
for bench in target_benches:
    bench_path = Path(f"data/court/cnrorders/{bench}")
    if not bench_path.exists():
        continue          # <- also skips write_scraped_through_date()
```

A bench that is simply quiet therefore never gets a `scraped_through_date` at all,
and `_extract_resume_cursor_from_index` falls back to the legacy max-filename date.
`run()` then resolves a court's start date as the **MIN across its benches**, so one
quiet bench pins the whole court.

Verified against the public bucket:

| court | bench | `scraped_through_date` |
|---|---|---|
| 27_1 Bombay | `newos`, `newas`, `kolhcdb`, `hcaurdb`, `newos_spl`, `testcase` | `2026-08-04` |
| 27_1 Bombay | **`hcbgoa`** | **`null`** (legacy fallback → `2025-10-17`) |
| 9_13 Allahabad | `cishclko` | `2026-08-23` |
| 9_13 Allahabad | **`cisdb_16012018`** | **`2026-06-30`** (frozen) |

Replaying `_extract_resume_cursor_from_index` + the `min()` over those real index
files reproduces `2025-10-17` — byte-identical to the `from_date` in the 08-23 run
log. So Bombay re-scrapes a ~10-month window *every single day*.

This was only wasteful while those rows were already in S3 — on 3 August the full
25-court run took 1h02 with `downloaded=0` for Bombay. Then PDF download outcomes
flipped (`Non-PDF response` errors: 4,110 on 08-04, 13,751 on 08-05, 18 by 08-23),
the 10-month window turned into real download work, and it stopped fitting in six
hours. The pin is the defect; the portal wobble was only the trigger.

The existing health gate can't catch this: `FAILURE_RATIO_THRESHOLD` is evaluated
after the court loop, and a run killed at the 6h cap never gets there.

### The fix

1. **Advance the resume cursor for every bench of a court, not just the busy ones**
   (`_advance_court_resume_cursors`). The search is issued per court, so a bench
   with no rows in the range *has* been covered — "no judgments" is not "not looked
   at". This is the actual unpin: Bombay's window collapses from ~10 months to the
   14-day overlap and the daily run goes back to ~1h.
2. **Only advance as far as a court is contiguously covered**
   (`_contiguous_scraped_through`). The cursor stops the day before the earliest
   failed or unrun range, so (1) can never step over a gap. This also makes partial
   progress *converge*: a court that is time-boxed keeps the ground it gained.
3. **Bound the run** with `--max-runtime-minutes` (default 300, set to 300 in the
   workflow) so it stops starting work below the CI cap and drains its uploads
   instead of being killed mid-write.
4. **Fail loudly.** A court that was never attempted, or a range that never ran,
   raises and exits non-zero. This is deliberately stricter than the existing
   `FAILURE_RATIO_THRESHOLD` tolerance, and I think the distinction holds: an
   attempted-and-partly-failed range is transient and self-heals next run, but a
   court that was never touched is a silent data gap.
5. `timeout-minutes: 350` on the job as a backstop under the 6h cap.

### Considered and rejected

- **Changing the bench cursor `min()` to `max()`.** It would shrink Bombay's window
  immediately, but it permanently abandons the lagging bench's gap, and the comment
  in `run()` shows the `min()` was chosen knowingly. Fixing the missing cursor is
  the narrower fix.
- **Court rotation.** Redundant once a court can't consume the whole budget, and a
  behaviour change you may not want.

### Also noticed — not fixed here

There is an O(n²) page re-walk in `download()`: after every `NO_CAPTCHA_BATCH_SIZE`
downloads it re-fetches the *same* page from row 0, since
`_refresh_search_pagination` deliberately keeps `iDisplayStart`. The re-fetch itself
is necessary — `pdf_link_payload["val"] = row_pos` is positional against server-side
session state — but the re-*walk* is waste. The signature is exact in your logs:

```
downloaded=350   session_refreshes=14  skip_local=2275   (= 25 x (1+...+13))
downloaded=1025  session_refreshes=41  skip_local=20490  (≈ 25 x (1+...+40))
```

I left it alone: measured against your own tqdm rates (~400 rows/s) it is ~51s of a
~3,500s task, i.e. **~1.5% of wall-clock — not the cause of the overrun**. Happy to
send it as a separate PR (resume at the row offset after refresh) if useful.

### Testing

- Existing suite: 17/17 pass before and after (`python -m unittest discover -s tests`).
- Added 6 tests in the same `unittest` style: quiet-bench cursor advance, explicit
  `scraped_through` override, contiguous-cursor arithmetic, deadline cancellation,
  and unattempted-court failure.
- `test_bench_with_no_new_files_still_advances_its_cursor` **fails on `main`** and
  passes with this patch, so it pins the actual defect.

**What I could not verify:** I have no AWS credentials or eCourts access, so I have
not exercised a real run. Specifically unverified: that a live run now completes
inside the budget; the real portal interaction; and how long Bombay's backlog takes
to drain once its cursor starts advancing. The reasoning that the budget is
sufficient rests on your 3 August log (all 25 courts in 1h02 with Bombay unpinned),
not on a run of my own. `--max-runtime-minutes 300` may need tuning on first use.